### PR TITLE
docs: add self-signed certificate instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+backend/certs/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Morning Control Protocol
+
+## Generating self-signed certificates
+
+For local development, you may need HTTPS certificates.
+
+1. Create a directory for certificates:
+   ```bash
+   mkdir -p backend/certs
+   ```
+2. Generate a new self-signed certificate and private key:
+   ```bash
+   openssl req -x509 -nodes -newkey rsa:2048 -keyout backend/certs/server.key -out backend/certs/server.crt -days 365 -subj "/CN=localhost"
+   ```
+3. Use `backend/certs/server.crt` and `backend/certs/server.key` for local HTTPS servers. **Do not commit these files**; they are ignored via `.gitignore`.
+


### PR DESCRIPTION
## Summary
- ignore backend certificate keys
- document generating self-signed certificates for local development

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689e06b45cb88323a978855ea522e5b0