### PR TITLE
Add SQLite helper with parameterized insert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+database.sqlite
+*.db

--- a/db.js
+++ b/db.js
@@ -1,0 +1,33 @@
+const Database = require('better-sqlite3');
+const path = require('path');
+
+const dbPath = path.join(__dirname, 'database.sqlite');
+const db = new Database(dbPath);
+
+function init() {
+  return new Promise((resolve, reject) => {
+    try {
+      db.prepare(`CREATE TABLE IF NOT EXISTS messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        content TEXT NOT NULL
+      )`).run();
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+function insertMessage(content) {
+  return new Promise((resolve, reject) => {
+    try {
+      const stmt = db.prepare('INSERT INTO messages (content) VALUES (?)');
+      const info = stmt.run(content);
+      resolve(info.lastInsertRowid);
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+module.exports = { init, insertMessage };

--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "usage": "node usage.js"
   },
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "next": "^13.4.0",
-    "lucide-react": "^0.263.1"
+    "lucide-react": "^0.263.1",
+    "better-sqlite3": "^8.6.0"
   },
   "devDependencies": {
     "tailwindcss": "^3.3.0",

--- a/usage.js
+++ b/usage.js
@@ -1,0 +1,13 @@
+const { init, insertMessage } = require('./db');
+
+async function run() {
+  try {
+    await init();
+    const id = await insertMessage('hello from usage');
+    console.log('Inserted row with id:', id);
+  } catch (err) {
+    console.error('Database error:', err);
+  }
+}
+
+run();


### PR DESCRIPTION
## Summary
- add better-sqlite3 dependency and usage script
- implement db helper with parameterized CREATE TABLE and INSERT
- example script awaiting async insert

## Testing
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*
- `node usage.js` *(fails: Cannot find module 'better-sqlite3')*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e07b77bf083239d7a0447c3512844