### PR TITLE
feat: integrate gpt tokenizer for usage metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "next": "^13.4.0",
-    "lucide-react": "^0.263.1"
+    "lucide-react": "^0.263.1",
+    "gpt-tokenizer": "^1.0.0"
   },
   "devDependencies": {
     "tailwindcss": "^3.3.0",

--- a/usage.js
+++ b/usage.js
@@ -1,0 +1,19 @@
+const assert = require('assert');
+const { countTokens } = require('./utils/tokenizer');
+
+function runExamples() {
+  const examples = [
+    { text: 'Hello, world!', expected: 4 },
+    { text: 'The quick brown fox jumps over the lazy dog.', expected: 11 }
+  ];
+
+  examples.forEach(({ text, expected }) => {
+    const count = countTokens(text);
+    console.log(`"${text}" -> ${count} tokens`);
+    if (typeof expected === 'number') {
+      assert.strictEqual(count, expected, `Token count mismatch for: ${text}`);
+    }
+  });
+}
+
+runExamples();

--- a/utils/tokenizer.js
+++ b/utils/tokenizer.js
@@ -1,0 +1,14 @@
+const { encode } = require('gpt-tokenizer');
+
+function countTokens(input) {
+  if (Array.isArray(input)) {
+    return input.reduce((sum, item) => sum + countTokens(item), 0);
+  }
+  if (typeof input !== 'string') {
+    input = String(input);
+  }
+  const tokens = encode(input);
+  return tokens.length;
+}
+
+module.exports = { countTokens };


### PR DESCRIPTION
## Summary
- add gpt-tokenizer dependency and utility to count tokens via encode
- include usage script with sample token assertions

## Testing
- `npm test` *(fails: Missing script "test")*
- `node usage.js` *(fails: Cannot find module 'gpt-tokenizer')*


------
https://chatgpt.com/codex/tasks/task_e_689e090d2c1883238ee4d0ef4034eda3