### PR TITLE
Add API tests and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+usage.db

--- a/__tests__/prompt.test.js
+++ b/__tests__/prompt.test.js
@@ -1,0 +1,57 @@
+jest.mock('../lib/model', () => ({
+  generate: jest.fn(() => Promise.resolve('mocked response'))
+}));
+
+const request = require('supertest');
+const express = require('express');
+const handler = require('../pages/api/prompt');
+const { VALID_TOKEN } = require('../lib/auth');
+const db = require('../lib/db');
+const model = require('../lib/model');
+
+const app = express();
+app.use(express.json());
+app.post('/prompt', handler);
+
+describe('auth middleware', () => {
+  test('rejects missing token', async () => {
+    await request(app).post('/prompt').send({ prompt: 'hi' }).expect(401);
+  });
+
+  test('rejects invalid token', async () => {
+    await request(app)
+      .post('/prompt')
+      .set('Authorization', 'Bearer bad')
+      .send({ prompt: 'hi' })
+      .expect(401);
+  });
+});
+
+describe('/prompt handler', () => {
+  beforeEach(done => {
+    db.run('DELETE FROM usage', done);
+  });
+
+  test('returns model output and records usage', async () => {
+    const res = await request(app)
+      .post('/prompt')
+      .set('Authorization', `Bearer ${VALID_TOKEN}`)
+      .send({ prompt: 'hello' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ output: 'mocked response' });
+    expect(model.generate).toHaveBeenCalledWith('hello');
+
+    await new Promise((resolve, reject) => {
+      db.get(
+        'SELECT prompt, output FROM usage ORDER BY id DESC LIMIT 1',
+        (err, row) => {
+          if (err) return reject(err);
+          expect(row.prompt).toBe('hello');
+          expect(row.output).toBe('mocked response');
+          resolve();
+        }
+      );
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node'
+};

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,0 +1,14 @@
+const VALID_TOKEN = 'test-token';
+
+function withAuth(handler) {
+  return (req, res) => {
+    const auth = req.headers['authorization'];
+    if (!auth || auth !== `Bearer ${VALID_TOKEN}`) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    return handler(req, res);
+  };
+}
+
+module.exports = { withAuth, VALID_TOKEN };

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,0 +1,14 @@
+const sqlite3 = require('sqlite3').verbose();
+
+const db = new sqlite3.Database(':memory:');
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS usage (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    prompt TEXT,
+    output TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  )`);
+});
+
+module.exports = db;

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,0 +1,5 @@
+async function generate(prompt) {
+  return `echo: ${prompt}`;
+}
+
+module.exports = { generate };

--- a/package.json
+++ b/package.json
@@ -6,17 +6,21 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "next": "^13.4.0",
-    "lucide-react": "^0.263.1"
+    "lucide-react": "^0.263.1",
+    "sqlite3": "^5.1.7"
   },
   "devDependencies": {
     "tailwindcss": "^3.3.0",
     "autoprefixer": "^10.4.14",
-    "postcss": "^8.4.24"
+    "postcss": "^8.4.24",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/pages/api/prompt.js
+++ b/pages/api/prompt.js
@@ -1,0 +1,18 @@
+const db = require('../../lib/db');
+const { withAuth } = require('../../lib/auth');
+const model = require('../../lib/model');
+
+async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+  const { prompt } = req.body;
+  const output = await model.generate(prompt);
+  db.run('INSERT INTO usage (prompt, output) VALUES (?, ?)', [prompt, output], err => {
+    if (err) console.error(err);
+  });
+  res.status(200).json({ output });
+}
+
+module.exports = withAuth(handler);


### PR DESCRIPTION
## Summary
- add Jest test script and dependencies
- implement auth middleware, prompt endpoint, SQLite logging, and model stub
- add tests covering authentication, prompt response, and usage recording
- configure CI to run tests

## Testing
- `npm install` *(fails: 403 Forbidden for jest)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e0c010df883238cdfe3c7571e3905