### PR TITLE
Add dotenv dependency and env var checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+PORT=3000
+MODEL_PATH=path/to/model
+LLAMA_BIN=path/to/llama
+JWT_SECRET=change_me

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Morning Control Protocol
+
+## Setup
+
+1. Copy `.env.example` to `.env`.
+2. Fill in the values for `PORT`, `MODEL_PATH`, `LLAMA_BIN`, and `JWT_SECRET`.
+3. Install dependencies:
+   ```bash
+   npm install
+   ```
+4. Start the development server:
+   ```bash
+   npm run dev
+   ```

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,11 @@
+require('dotenv').config();
+
+const requiredVars = ['PORT', 'MODEL_PATH', 'LLAMA_BIN', 'JWT_SECRET'];
+const missing = requiredVars.filter((name) => !process.env[name]);
+
+if (missing.length) {
+  console.error(`Missing required environment variables: ${missing.join(', ')}`);
+  process.exit(1);
+}
+
+// Backend server logic goes here.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "dotenv": "^16.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "next": "^13.4.0",


### PR DESCRIPTION
## Summary
- add dotenv dependency and sample .env file
- validate required environment variables in backend startup
- document copying `.env.example` to `.env`

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*
- `npm test` *(fails: Missing script: "test")*
- `node backend/index.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_689e0ab1b878832394439668434dbf6d